### PR TITLE
feat: enhance variable handling in Gitlab trigger function

### DIFF
--- a/gitlab.go
+++ b/gitlab.go
@@ -78,6 +78,15 @@ func (g *Gitlab) trigger(id string, params url.Values, body interface{}) (err er
 	if err := w.WriteField("ref", params.Get("ref")); err != nil {
 		return err
 	}
+	// Remove token and ref from params
+	params.Del("token")
+	params.Del("ref")
+
+	for key := range params {
+		if err := w.WriteField(fmt.Sprintf("variables[%s]", key), params.Get(key)); err != nil {
+			return err
+		}
+	}
 	w.Close()
 
 	req, err := http.NewRequest("POST", requestURL, &b)

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -64,6 +65,11 @@ func main() {
 			Usage:  "debug mode",
 			EnvVar: "PLUGIN_DEBUG,GITLAB_DEBUG,INPUT_DEBUG",
 		},
+		cli.StringSliceFlag{
+			Name:   "variables",
+			Usage:  "gitlab-ci variables",
+			EnvVar: "PLUGIN_VARIABLES,GITLAB_VARIABLES,INPUT_VARIABLES",
+		},
 	}
 
 	// Override a template
@@ -106,12 +112,22 @@ REPOSITORY:
 }
 
 func run(c *cli.Context) error {
+	variables := make(map[string]string)
+
+	for _, v := range c.StringSlice("variables") {
+		s := strings.Split(v, "=")
+		if len(s) == 2 {
+			variables[s[0]] = s[1]
+		}
+	}
+
 	plugin := Plugin{
-		Host:  c.String("host"),
-		Token: c.String("token"),
-		Ref:   c.String("ref"),
-		ID:    c.String("id"),
-		Debug: c.Bool("debug"),
+		Host:      c.String("host"),
+		Token:     c.String("token"),
+		Ref:       c.String("ref"),
+		ID:        c.String("id"),
+		Debug:     c.Bool("debug"),
+		Variables: variables,
 	}
 
 	return plugin.Exec()

--- a/plugin.go
+++ b/plugin.go
@@ -10,11 +10,12 @@ import (
 type (
 	// Plugin values.
 	Plugin struct {
-		Host  string
-		Token string
-		Ref   string
-		ID    string
-		Debug bool
+		Host      string
+		Token     string
+		Ref       string
+		ID        string
+		Debug     bool
+		Variables map[string]string
 	}
 
 	// Commit struct
@@ -57,11 +58,14 @@ func (p Plugin) Exec() error {
 		"ref":   []string{p.Ref},
 	}
 
+	for key, value := range p.Variables {
+		params[key] = []string{value}
+	}
+
 	body := &Commit{}
 
 	err := ci.trigger(p.ID, params, body)
 	if err != nil {
-		log.Println("gitlab-ci error:", err.Error())
 		return err
 	}
 


### PR DESCRIPTION
- Remove token and ref from parameters in the Gitlab trigger function
- Add support for variables in the main function using a StringSliceFlag
- Create a map for variables and populate it from the command line arguments
- Include variables in the Plugin struct
- Update the Exec method to handle the new variables map

fix https://github.com/appleboy/drone-gitlab-ci/issues/6